### PR TITLE
Selection of the correct agreement index via the config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This plugin enables homebridge to communicate with Toon.
 
 `npm install -g homebridge-toon`
 
+## Configuration
 The following should be added to the homebridge config.json:
 
     {
@@ -15,3 +16,10 @@ The following should be added to the homebridge config.json:
         }
       ]
     }
+
+## Agreement Selection
+The plugin automatically selects the first agreement in the list, however if agreement selection is necessary, add the following config parameter. 
+`"agreementIndex": <NUMBER>`
+
+The plugin automatically lists the available options in the Homebridge log.
+

--- a/index.js
+++ b/index.js
@@ -14,7 +14,15 @@ module.exports = function (homebridge) {
 function ToonAccessory(log, config) {
     this.log = log;
     this.name = config.name;
-    this.toon = toon(config.username, config.password, this.log);
+
+    // Index selecting the agreement, if a user has multiple agreements (due to moving, etc.).
+    var agreementIndex = 0;
+
+    if (config.agreementIndex !== undefined) {
+        agreementIndex = config.agreementIndex;
+    }
+
+    this.toon = toon(config.username, config.password, agreementIndex, this.log);
 
     var self = this;
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var request = require("request");
-var toon = require("./toon");
+var Toon = require("./toon");
 var Accessory, Service, Characteristic, UUIDGen;
 
 module.exports = function (homebridge) {
@@ -16,13 +16,13 @@ function ToonAccessory(log, config) {
     this.name = config.name;
 
     // Index selecting the agreement, if a user has multiple agreements (due to moving, etc.).
-    var agreementIndex = 0;
+    this.agreementIndex = 0;
 
     if (config.agreementIndex !== undefined) {
-        agreementIndex = config.agreementIndex;
+        this.agreementIndex = config.agreementIndex;
     }
 
-    this.toon = toon(config.username, config.password, agreementIndex, this.log);
+    this.toon = Toon(config.username, config.password, this.agreementIndex, this.log);
 
     var self = this;
 

--- a/toon.js
+++ b/toon.js
@@ -109,6 +109,23 @@ Toon.prototype = {
             var body = response.body;
             if (response.statusCode == 200 && (typeof body !== "undefined") && body.success === true) {
                 self.clientData = body;
+
+                if (self.initialized === false && body.hasOwnProperty('agreements')) {
+                    if (self.agreementIndex < body.agreements.length) {
+                        self.log("Currently selected agreementIndex: " + self.agreementIndex);
+                    } else {
+                        throw new Error('Incorrect agreementIndex selected, is your config valid?');
+                    }
+
+                    for (var i = 0; i < body.agreements.length; i++) {
+                        var agreement = body.agreements[i];
+                        self.log("agreementIndex: [" + i + "]: "
+                            + agreement.street + " " + agreement.houseNumber
+                            + " " + agreement.postalCode + " " + agreement.city
+                            + " - " + agreement.heatingType);
+                    }
+                }
+
             } else {
                 throw new Error('There was an error retrieving the client data from Toon.\n' + JSON.stringify(body));
             }
@@ -225,6 +242,6 @@ Toon.prototype = {
     }
 };
 
-module.exports = function(username, password, log) {
-	return new Toon(username, password, log);
+module.exports = function(username, password, agreementIndex, log) {
+	return new Toon(username, password, agreementIndex, log);
 };

--- a/toon.js
+++ b/toon.js
@@ -4,12 +4,12 @@ var express = require('express');
 var uuid = require('node-uuid');
 var events = require('events');
 
-function Toon(username, password, log) {
+function Toon(username, password, agreementIndex, log) {
 	this.username = username;
 	this.password = password;
 	this.log = log;
     this.emitter = new events.EventEmitter();
-
+    this.agreementIndex = agreementIndex;
 
     this.authenticating = false;
 	this.initialized = false;
@@ -79,8 +79,8 @@ Toon.prototype = {
             qs: {
                 clientId: self.clientData.clientId,
                 clientIdChecksum: self.clientData.clientIdChecksum,
-                agreementId: self.clientData.agreements[0].agreementId,
-                agreementIdChecksum: self.clientData.agreements[0].agreementIdChecksum,
+                agreementId: self.clientData.agreements[self.agreementIndex].agreementId,
+                agreementIdChecksum: self.clientData.agreements[self.agreementIndex].agreementIdChecksum,
                 random: uuid.v4()
             },
             json: true,


### PR DESCRIPTION
- Allows the selection of a Toon Agreement from the config file. The plugin logs the available agreements, which can be selected by extending the accessory config with 
`"agreementIndex": <AGREEMENTNUMBER>` 

This branch can be tested by installing using: `npm install -g jochem725/homebridge-toon#agreementid`